### PR TITLE
Add `new-section` to Typst template

### DIFF
--- a/typst/Readme.md
+++ b/typst/Readme.md
@@ -2,10 +2,15 @@
 
 Just add the following to your typst file:
 
-```typ
+````typ
 #import "texmf/typst/sraslides.typ": *
 
-#let title = [ Making a Good Presentation ]
+#let title = "Making a Good Presentation"
+#let author = "Max Mustermann"
+#let date = datetime.today()
+
+// Sets metadata for the document
+#set document(title: title, author: author, date: date)
 
 #show: theme.with(title: title)
 
@@ -17,16 +22,24 @@ Just add the following to your typst file:
 
     = #title
 
-    #v(45pt)
-
-    *Max Mustermann*
+    *#author*
 
     Institute for Systems Engineering
 
-    #datetime.today().display("[day]. [month repr:short] [year]")
+    #date.display("[day]. [month repr:short] [year]")
 ]
 
-#frame(title: [The Rust Programming Language])[
+// This aggregates all sections
+#frame(title: "Outline")[
+  #utils.polylux-outline()
+]
+
+#frame(
+  title: [The Rust Programming Language],
+  // This creates a new section visible in the footer and the outline.
+  // You can also pass a custom name here
+  new-section: true,
+)[
     #side-by-side[
         - Developed by Mozilla in 2015
             - Independent Rust Foundation
@@ -46,4 +59,20 @@ Just add the following to your typst file:
         - ...
     ]
 ]
-```
+
+// This slide is part of the previous section
+#frame(title: "Hello World")[
+    #box(
+      inset: 1em,
+      fill: luma(240),
+      stroke: luma(200) + 1pt,
+      radius: 0.5em
+    )[```rust
+      fn main() {
+        println!("Hello, World!");
+      }
+      ```]
+]
+````
+
+For more documentation, take a look at the [Polylux book](https://polylux.dev/book/polylux.html).

--- a/typst/sraslides.typ
+++ b/typst/sraslides.typ
@@ -71,17 +71,39 @@
 }
 
 /// Create a new slide with the given title
-#let frame(body, title: []) = polylux-slide([
-    #grid(
-        columns: (30pt, 1fr, 80pt),
-        rows: (auto, 1fr),
-        gutter: 2.5pt,
-        sra-logo(height: 16pt),
-        align(left + horizon, heading(title)),
-        align(horizon + right, luh-logo(height: 16pt)),
-        grid.cell(colspan: 3, align(horizon + left, block(inset: (left: 12pt, right: 12pt), width: 100%, height: 100%, body)))
-    )
-])
+///
+/// `title`: The title of this slide (type: content)
+/// `new-section`: If set, this slide will create a new section named `title`
+///                if `new-section` is `true`, otherwise the value of
+///                `new-section` is used.
+///                `none` or `false` do nothing(default).
+#let frame(
+    body,
+    title: [],
+    new-section: none,
+) = {
+    polylux-slide({
+        // register new section here, so it doesn't leak into the previous slide
+        if new-section != none and new-section != false {
+            let section-name = if new-section == true {
+                title
+            } else {
+                new-section
+            }
+            utils.register-section(section-name)
+        }
+
+        grid(
+            columns: (30pt, 1fr, 80pt),
+            rows: (auto, 1fr),
+            gutter: 2.5pt,
+            sra-logo(height: 16pt),
+            align(left + horizon, heading(title)),
+            align(horizon + right, luh-logo(height: 16pt)),
+            grid.cell(colspan: 3, align(horizon + left, block(inset: (left: 12pt, right: 12pt), width: 100%, height: 100%, body)))
+        )
+    })
+}
 
 /// Create a block with a title and a body
 #let title-block(title: (), fill: luh.blue, body) = [


### PR DESCRIPTION
This PR adds a new parameter to `#frame` - `new-section`. When specified, it creates a new section for the current slide. It can be `true`, in which case it uses the title as the section name, or of type `content` that is used as the section name.

I've updated the example in the documentation to use this parameter, demonstrate the absence of it, and show a basic outline.

The `#v(45pt)` in the title slide caused some parts to be wrapped onto a new page, so I removed it. Furthermore, I've added metadata to the `document`.